### PR TITLE
Add attendance time slot and confirmation status to registration process

### DIFF
--- a/app/api/events/registration/[eventId]/route.ts
+++ b/app/api/events/registration/[eventId]/route.ts
@@ -43,13 +43,29 @@ export async function POST(
         company,
       },
     });
-    await db.attendance.create({
+    const attendance = await db.attendance.create({
       data: { attendeeId: user.id, eventId: event.id },
     });
+    const attendances = await db.attendance.findMany({
+      where: { eventId: params.eventId },
+    });
+
+    let timeSlot;
+    if (attendances.length < 13) {
+      timeSlot = "10:00AM - 1:00PM";
+    } else {
+      timeSlot = "2:00PM - 5:00PM";
+    }
     const emailVerificationResponse = await sendEmail({
       toEmail: email,
       subject: "Registration Successful",
-      message: `Hello ${name}, your registration for ${event?.title} was recorded. Thank you for your continued support.`,
+      message: `Hello ${name}, your registration for ${event?.title} was recorded. See you on Wednesday the 24th from ${timeSlot}. \n\n Thank you for your continued support.`,
+    });
+    await db.attendance.update({
+      where: { id: attendance.id },
+      data: {
+        confirmed: true,
+      },
     });
     if (emailVerificationResponse.status === 200) {
       return NextResponse.json(

--- a/prisma/migrations/20240422122020_004/migration.sql
+++ b/prisma/migrations/20240422122020_004/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "Attendance" ADD COLUMN     "confirmed" BOOLEAN NOT NULL DEFAULT false,
+ADD COLUMN     "createdAt" TIMESTAMP(3) DEFAULT CURRENT_TIMESTAMP,
+ADD COLUMN     "timeSlot" TEXT,
+ADD COLUMN     "updatedAt" TIMESTAMP(3);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -58,7 +58,7 @@ model Event {
 }
 
 model Attendee {
-  id          String @id @default(uuid())
+  id          String  @id @default(uuid())
   name        String
   email       String
   phoneNumber String
@@ -70,6 +70,12 @@ model Attendance {
   eventId String
 
   attendeeId String
+
+  createdAt DateTime? @default(now())
+  updatedAt DateTime? @updatedAt
+
+  timeSlot  String?
+  confirmed Boolean @default(false)
 
   @@unique([eventId, attendeeId])
 }


### PR DESCRIPTION
Update the registration process to include a time slot based on the number of attendees and add a confirmation status to attendance records. This involves updating the database schema and the registration route logic.